### PR TITLE
#29 Рефакторинг экрана списка эвентов.

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:ows_events_mobile/features/events/presentation/events_screen.dart';
+import 'package:ows_events_mobile/features/main/presentation/main_screen.dart';
 import 'package:ows_events_mobile/theme/app_theme.dart';
 
 class App extends StatelessWidget {
@@ -11,7 +11,7 @@ class App extends StatelessWidget {
       title: 'Afisha Peredelano',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.theme,
-      home: const EventsScreen(),
+      home: const MainScreen(),
     );
   }
 }

--- a/lib/common_widgets/info_icon_button.dart
+++ b/lib/common_widgets/info_icon_button.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class InfoIconButton extends StatelessWidget {
+  const InfoIconButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: () {
+        throw UnimplementedError();
+      },
+      icon: const Icon(
+        Icons.info_outline_rounded,
+        size: 35,
+      ),
+    );
+  }
+}

--- a/lib/common_widgets/logo.dart
+++ b/lib/common_widgets/logo.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class Logo extends StatelessWidget {
+  const Logo({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.asset('assets/logo.png');
+  }
+}

--- a/lib/core/dio.dart
+++ b/lib/core/dio.dart
@@ -1,0 +1,4 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final dioProvider = Provider<Dio>((ref) => Dio());

--- a/lib/features/events/data/api/events_api.dart
+++ b/lib/features/events/data/api/events_api.dart
@@ -1,4 +1,6 @@
 import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ows_events_mobile/core/dio.dart';
 import 'package:ows_events_mobile/features/events/data/response/event_response.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -11,3 +13,5 @@ abstract class EventsApi {
   @GET("events")
   Future<List<EventResponse>> getEvents();
 }
+
+final eventsApiProvider = Provider((ref) => EventsApi(ref.read(dioProvider)));

--- a/lib/features/events/data/events_repository.dart
+++ b/lib/features/events/data/events_repository.dart
@@ -1,12 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ows_events_mobile/features/events/domain/event.dart';
 import 'package:ows_events_mobile/features/events/domain/location.dart';
 
 import 'api/events_api.dart';
 
 class EventsRepository {
-  final EventsApi api;
-
   EventsRepository(this.api);
+
+  final EventsApi api;
 
   Future<List<Event>> getEvents() async {
     final eventsResponse = await api.getEvents();
@@ -14,6 +15,7 @@ class EventsRepository {
     return eventsResponse.map((e) {
       var date = e.date;
       var durationInSeconds = e.durationInSeconds;
+
       return Event(
         id: e.id,
         title: e.title,
@@ -30,6 +32,9 @@ class EventsRepository {
         url: e.url,
         image: e.image,
       );
-    }).toList(growable: false);
+    }).toList();
   }
 }
+
+final eventsRepositoryProvider =
+    Provider((ref) => EventsRepository(ref.read(eventsApiProvider)));

--- a/lib/features/events/presentation/events_list.dart
+++ b/lib/features/events/presentation/events_list.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:ows_events_mobile/features/events/domain/event.dart';
+import 'package:ows_events_mobile/features/events/presentation/events_list_controller.dart';
+import 'package:ows_events_mobile/features/events/presentation/events_list_item.dart';
+import 'package:ows_events_mobile/util/time_utils.dart';
+
+class EventsList extends ConsumerWidget {
+  const EventsList({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<List<Event>> asyncEventsListData =
+        ref.watch(eventsListControllerProvider);
+
+    return asyncEventsListData.when(
+      data: (events) => CustomScrollView(
+        slivers: [
+          SliverAppBar.medium(
+            title: const Text('Мероприятия'),
+          ),
+          SliverList.builder(
+            itemCount: events.length,
+            itemBuilder: (context, index) {
+              final Event event = events[index];
+
+              return EventsListItem(
+                title: event.title,
+                description: event.description,
+                date: TimeUtils.formatDateTime(event.date),
+                venueLinkText:
+                    '${event.location.country}, ${event.location.city}',
+                image: event.image,
+                price: event.price.toString(),
+                venueLinkAction: () {
+                  // TODO: реализовать клик по месту проведения
+                  throw UnimplementedError();
+                },
+                itemAction: () {
+                  // TODO: реализовать клик по эвенту
+                  throw UnimplementedError();
+                },
+              );
+            },
+          ),
+        ],
+      ),
+      // TODO: в дальнейшем заменить на виджет для вывода ошибки
+      error: (error, _) => Text(error.toString()),
+      loading: () => const CircularProgressIndicator(),
+    );
+  }
+}

--- a/lib/features/events/presentation/events_list_controller.dart
+++ b/lib/features/events/presentation/events_list_controller.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logger/logger.dart';
+import 'package:ows_events_mobile/core/logger.dart';
+import 'package:ows_events_mobile/features/events/data/events_repository.dart';
+import 'package:ows_events_mobile/features/events/domain/event.dart';
+
+class EventsListController extends StateNotifier<AsyncValue<List<Event>>> {
+  EventsListController({
+    required this.logger,
+    required this.repository,
+  }) : super(const AsyncData([])) {
+    init();
+  }
+
+  final Logger logger;
+  final EventsRepository repository;
+
+  init() async {
+    state = const AsyncLoading();
+
+    try {
+      final List<Event> eventsList = await repository.getEvents();
+
+      if (mounted == true) {
+        state = AsyncData(eventsList);
+      }
+    } catch (error) {
+      state = AsyncError(error, StackTrace.current);
+      logger.e('EventsListController.init', error, StackTrace.current);
+    }
+  }
+}
+
+final eventsListControllerProvider =
+    StateNotifierProvider<EventsListController, AsyncValue<List<Event>>>(
+        (ref) => EventsListController(
+              logger: ref.read(loggerProvider),
+              repository: ref.read(eventsRepositoryProvider),
+            ));

--- a/lib/features/events/presentation/events_list_item.dart
+++ b/lib/features/events/presentation/events_list_item.dart
@@ -2,32 +2,34 @@ import 'package:flutter/material.dart';
 import 'package:ows_events_mobile/resources/colors.dart';
 import 'package:ows_events_mobile/resources/text_styles.dart';
 
-class EventListItem extends StatelessWidget {
+class EventsListItem extends StatelessWidget {
+  const EventsListItem({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.date,
+    required this.price,
+    required this.venueLinkText,
+    required this.image,
+    required this.venueLinkAction,
+    required this.itemAction,
+  });
+
   final String title;
   final String description;
   final String date;
   final String price;
-  final String linkText;
+  final String venueLinkText;
   final String image;
-  final VoidCallback linkAction;
+  final VoidCallback venueLinkAction;
   final VoidCallback itemAction;
-
-  const EventListItem(
-      {super.key,
-      required this.title,
-      required this.description,
-      required this.date,
-      required this.price,
-      required this.linkText,
-      required this.image,
-      required this.linkAction,
-      required this.itemAction});
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
       onTap: itemAction,
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SizedBox(
             height: 176,
@@ -36,24 +38,24 @@ class EventListItem extends StatelessWidget {
               children: [
                 Image.network(image, fit: BoxFit.fitWidth),
                 Positioned(
-                    top: 12,
-                    left: 16,
-                    child: Container(
-                      padding: const EdgeInsets.fromLTRB(4, 10, 4, 10),
-                      decoration: BoxDecoration(
-                          color: AppColors.accent,
-                          borderRadius: BorderRadius.circular(16)),
-                      child: Text(
-                        price,
-                        style: AppTextStyles.priceTextStyle,
-                      ),
-                    ))
+                  top: 12,
+                  left: 16,
+                  child: Container(
+                    padding: const EdgeInsets.fromLTRB(4, 10, 4, 10),
+                    decoration: BoxDecoration(
+                        color: AppColors.accent,
+                        borderRadius: BorderRadius.circular(16)),
+                    child: Text(
+                      price,
+                      style: AppTextStyles.priceTextStyle,
+                    ),
+                  ),
+                ),
               ],
             ),
           ),
           Container(
             padding: const EdgeInsets.fromLTRB(16, 0, 15, 0),
-            alignment: Alignment.topLeft,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -61,7 +63,6 @@ class EventListItem extends StatelessWidget {
                   padding: const EdgeInsets.fromLTRB(0, 8, 0, 8),
                   child: Text(
                     description,
-                    textAlign: TextAlign.left,
                     style: AppTextStyles.secondaryText,
                   ),
                 ),
@@ -69,24 +70,23 @@ class EventListItem extends StatelessWidget {
                   padding: const EdgeInsets.fromLTRB(0, 0, 0, 8),
                   child: Text(
                     title,
-                    textAlign: TextAlign.left,
                     style: AppTextStyles.mainTextStyle,
                   ),
                 ),
                 Text(
                   date,
-                  textAlign: TextAlign.left,
                   style: AppTextStyles.secondaryText,
                 ),
                 Padding(
-                    padding: const EdgeInsets.fromLTRB(0, 8, 0, 44),
-                    child: GestureDetector(
-                        onTap: linkAction,
-                        child: Text(
-                          linkText,
-                          textAlign: TextAlign.left,
-                          style: AppTextStyles.linkTextStyle,
-                        )))
+                  padding: const EdgeInsets.fromLTRB(0, 8, 0, 44),
+                  child: GestureDetector(
+                    onTap: venueLinkAction,
+                    child: Text(
+                      venueLinkText,
+                      style: AppTextStyles.linkTextStyle,
+                    ),
+                  ),
+                ),
               ],
             ),
           )

--- a/lib/features/events/presentation/events_screen.dart
+++ b/lib/features/events/presentation/events_screen.dart
@@ -1,101 +1,11 @@
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:logger/logger.dart';
-import 'package:ows_events_mobile/core/logger.dart';
-import 'package:ows_events_mobile/features/events/data/api/events_api.dart';
-import 'package:ows_events_mobile/features/events/data/events_repository.dart';
-import 'package:ows_events_mobile/features/events/domain/event.dart';
-import 'package:ows_events_mobile/util/time_utils.dart';
-import 'package:ows_events_mobile/features/events/presentation/event_list_item.dart';
+import 'package:ows_events_mobile/features/events/presentation/events_list.dart';
 
-class EventsScreen extends ConsumerStatefulWidget {
+class EventsScreen extends StatelessWidget {
   const EventsScreen({super.key});
 
   @override
-  EventsScreenState createState() => EventsScreenState();
-}
-
-class EventsScreenState extends ConsumerState<EventsScreen> {
-  List<Event> events = [];
-  late Logger _logger;
-
-  @override
-  void initState() {
-    _logger = ref.read(loggerProvider);
-    super.initState();
-    final dio = Dio();
-    final eventsApi = EventsApi(dio);
-    final eventsRepo = EventsRepository(eventsApi);
-    loadData(eventsRepo);
-  }
-
-  Future<void> loadData(eventsRepo) async {
-    final loadedEvents = await eventsRepo.getEvents();
-    _logger.i(loadedEvents);
-    setState(() {
-      events = loadedEvents;
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final screenSize = MediaQuery.of(context).size;
-    final isSmallSizeScreen = screenSize.width <= 500;
-
-    return Center(
-      child: SizedBox(
-        width: isSmallSizeScreen ? double.infinity : 500,
-        child: Scaffold(
-          body: CustomScrollView(
-            slivers: [
-              SliverAppBar.large(
-                leading: Row(
-                  children: [Image.asset('assets/logo.png')],
-                ),
-                title: const Text('Мероприятия'),
-                actions: [
-                  Row(
-                    children: [
-                      const Text("30 дней до конца подписки"),
-                      IconButton(
-                          onPressed: () {},
-                          icon:
-                              const Icon(Icons.info_outline_rounded, size: 35)),
-                    ],
-                  )
-                ],
-              ),
-              SliverList.builder(
-                itemCount: events.length,
-                itemBuilder: (context, index) {
-                  Event event = events[index];
-                  return EventListItem(
-                      title: event.title,
-                      description: event.description,
-                      date: TimeUtils.formatDateTime(event.date),
-                      linkText:
-                          '${event.location.country}, ${event.location.city}',
-                      image: event.image,
-                      price: event.price.toString(),
-                      linkAction: () {
-                        ScaffoldMessenger.of(context).hideCurrentSnackBar();
-                        ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text("Click on link")));
-                        _logger.d('Click on link');
-                      },
-                      itemAction: () {
-                        ScaffoldMessenger.of(context).hideCurrentSnackBar();
-                        ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text("Click on item")));
-                        _logger.d('Click on item');
-                      });
-                },
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
+    return const EventsList();
   }
 }

--- a/lib/features/main/presentation/main_screen.dart
+++ b/lib/features/main/presentation/main_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:ows_events_mobile/common_widgets/info_icon_button.dart';
+import 'package:ows_events_mobile/common_widgets/logo.dart';
+import 'package:ows_events_mobile/features/events/presentation/events_screen.dart';
+
+class MainScreen extends StatelessWidget {
+  const MainScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final screenSize = MediaQuery.of(context).size;
+    final isSmallSizeScreen = screenSize.width <= 500;
+
+    return Container(
+      color: Theme.of(context).colorScheme.background,
+      child: Center(
+        child: SizedBox(
+          width: isSmallSizeScreen ? double.infinity : 500,
+          child: Scaffold(
+            appBar: AppBar(
+              leading: const Logo(),
+              leadingWidth: 150,
+              actions: const [
+                Text("30 дней"),
+                InfoIconButton(),
+              ],
+            ),
+            body: const EventsScreen(),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Разнесла экран на компоненты. Выделила основной экран (main screen). Вынесла Лого и Инфо-иконку-кнопку в отдельные виджете. Вынесла получение данных для списка событий в контроллер. Апи, репозиторий и контроллер обернула в провайдеры.